### PR TITLE
update README.md to use newest version 0.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the plugin to your gradle build file:
 
 ```kotlin
 plugins {
-     id("io.kotest") version "0.3.7"
+     id("io.kotest") version "0.3.8"
 }
 ```
 


### PR DESCRIPTION
I noticed that there is a newer version than one's written in README.md so just updated the document for others.

ref : https://plugins.gradle.org/plugin/io.kotest 