### PR TITLE
Remove dependency on deprecated conventions API

### DIFF
--- a/src/main/kotlin/io/kotest/gradle/sourcesets.kt
+++ b/src/main/kotlin/io/kotest/gradle/sourcesets.kt
@@ -2,6 +2,7 @@ package io.kotest.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.internal.DefaultJavaPluginConvention
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.extensibility.DefaultConvention
@@ -49,11 +50,7 @@ fun Project.mppTestTargets(): Map<KotlinTargetWithTests<*, *>, FileCollection> {
    }
 }
 
-fun Project.javaTestSourceSet(): SourceSet? {
-   return when (val java = convention.plugins["java"]) {
-      is DefaultJavaPluginConvention -> {
-         java.sourceSets.findByName("test")
-      }
-      else -> null
-   }
-}
+fun Project.javaTestSourceSet(): SourceSet? =
+   extensions.findByType(JavaPluginExtension::class.java)
+      ?.sourceSets
+      ?.findByName("test")


### PR DESCRIPTION
`Project.convention` and other conventions API methods have been
[deprecated](https://docs.gradle.org/current/userguide/upgrading_version_7.html#all_convention_deprecation] and will be removed in Gradle 9.0. To make things worse, the
`Project.convention.plugins["java"]` does not return
`DefaultJavaPluginConvention` anymore, but instead returns a wrapper
class that issues deprecation warnings. Since the plugin cannot find the
expected class, it stopped working properly (this is probably the cause
of #53).

This pull requests simply replaces the single use of
`Project.convention.plugins[]` (finding the Java test sourceset) with
`Project.extensions.findByType`.

Fixes: #42, #53
